### PR TITLE
Add servo flag

### DIFF
--- a/moz-webgpu-cts/src/main.rs
+++ b/moz-webgpu-cts/src/main.rs
@@ -47,6 +47,8 @@ use whippit::{
 struct Cli {
     #[clap(long)]
     gecko_checkout: Option<PathBuf>,
+    #[clap(long)]
+    servo: bool,
     #[clap(subcommand)]
     subcommand: Subcommand,
 }
@@ -125,6 +127,7 @@ fn run(cli: Cli) -> ExitCode {
     let Cli {
         gecko_checkout,
         subcommand,
+        servo,
     } = cli;
 
     let gecko_checkout = match gecko_checkout
@@ -136,8 +139,11 @@ fn run(cli: Cli) -> ExitCode {
     };
 
     let read_metadata = || -> Result<_, AlreadyReportedToCommandline> {
-        let webgpu_cts_meta_parent_dir =
-            { path!(&gecko_checkout | "testing" | "web-platform" | "mozilla" | "meta" | "webgpu") };
+        let webgpu_cts_meta_parent_dir = if !servo {
+            path!(&gecko_checkout | "testing" | "web-platform" | "mozilla" | "meta" | "webgpu")
+        } else {
+            path!(&gecko_checkout | "tests" | "wpt" | "webgpu" | "meta" | "webgpu")
+        };
 
         let mut found_err = false;
         let collected =

--- a/moz-webgpu-cts/src/main.rs
+++ b/moz-webgpu-cts/src/main.rs
@@ -1070,14 +1070,6 @@ fn run(cli: Cli) -> ExitCode {
                                 // We skip this because this test _should_ contain subtests with
                                 // `TIMEOUT` and `NOTRUN`, so we shouldn't actually miss anything.
                                 TestOutcome::Timeout => (),
-                                TestOutcome::Fail => receiver(&mut |analysis| {
-                                    insert_in_test_set(
-                                        &mut analysis.tests_with_fails,
-                                        test_name,
-                                        expectation,
-                                        outcome,
-                                    )
-                                }),
                                 TestOutcome::Crash => receiver(&mut |analysis| {
                                     insert_in_test_set(
                                         &mut analysis.tests_with_crashes,
@@ -1097,6 +1089,15 @@ fn run(cli: Cli) -> ExitCode {
                                 TestOutcome::Skip => receiver(&mut |analysis| {
                                     insert_in_test_set(
                                         &mut analysis.tests_with_disabled_or_skip,
+                                        test_name,
+                                        expectation,
+                                        outcome,
+                                    )
+                                }),
+                                TestOutcome::Pass => (),
+                                TestOutcome::Fail => receiver(&mut |analysis| {
+                                    insert_in_test_set(
+                                        &mut analysis.tests_with_fails,
                                         test_name,
                                         expectation,
                                         outcome,

--- a/moz-webgpu-cts/src/main.rs
+++ b/moz-webgpu-cts/src/main.rs
@@ -932,6 +932,7 @@ fn run(cli: Cli) -> ExitCode {
                 tests_with_runner_errors: TestSet,
                 tests_with_disabled_or_skip: TestSet,
                 tests_with_crashes: TestSet,
+                tests_with_fails: TestSet,
                 subtests_with_failures_by_test: SubtestByTestSet,
                 subtests_with_timeouts_by_test: SubtestByTestSet,
             }
@@ -1069,6 +1070,14 @@ fn run(cli: Cli) -> ExitCode {
                                 // We skip this because this test _should_ contain subtests with
                                 // `TIMEOUT` and `NOTRUN`, so we shouldn't actually miss anything.
                                 TestOutcome::Timeout => (),
+                                TestOutcome::Fail => receiver(&mut |analysis| {
+                                    insert_in_test_set(
+                                        &mut analysis.tests_with_fails,
+                                        test_name,
+                                        expectation,
+                                        outcome,
+                                    )
+                                }),
                                 TestOutcome::Crash => receiver(&mut |analysis| {
                                     insert_in_test_set(
                                         &mut analysis.tests_with_crashes,
@@ -1267,6 +1276,7 @@ fn run(cli: Cli) -> ExitCode {
                     tests_with_runner_errors,
                     tests_with_disabled_or_skip,
                     tests_with_crashes,
+                    tests_with_fails,
                     subtests_with_failures_by_test,
                     subtests_with_timeouts_by_test,
                 } = analysis;

--- a/moz-webgpu-cts/src/main.rs
+++ b/moz-webgpu-cts/src/main.rs
@@ -106,6 +106,8 @@ enum ReportProcessingPreset {
     #[value(alias("same-fx"))]
     Merge,
     ResetAll,
+    /// Set's only reported results to new value
+    Set,
     /// Resets only bad->good
     SetGood,
 }
@@ -630,6 +632,10 @@ fn run(cli: Cli) -> ExitCode {
                                     Some(rep) => meta | rep,
                                     None => meta,
                                 },
+                                ReportProcessingPreset::Set => |meta, rep| match rep {
+                                    Some(rep) => rep,
+                                    None => meta,
+                                },
                                 ReportProcessingPreset::SetGood => {
                                     |meta: Expectation<_>, rep: Option<Expectation<_>>| match rep {
                                         Some(rep) => {
@@ -684,7 +690,7 @@ fn run(cli: Cli) -> ExitCode {
 
                     if test_entry.reported.is_empty() {
                         match preset {
-                            ReportProcessingPreset::Merge => {
+                            ReportProcessingPreset::Merge | ReportProcessingPreset::Set => {
                                 log::warn!("no entries found in reports for {test_path:?}")
                             }
                             ReportProcessingPreset::ResetAll

--- a/moz-webgpu-cts/src/metadata.rs
+++ b/moz-webgpu-cts/src/metadata.rs
@@ -1118,11 +1118,12 @@ where
 #[serde(rename_all = "UPPERCASE")]
 pub enum TestOutcome {
     Ok,
-    Fail,
     Timeout,
     Crash,
     Error,
     Skip,
+    Pass,
+    Fail,
 }
 
 impl Default for TestOutcome {
@@ -1138,11 +1139,12 @@ impl Display for TestOutcome {
             "{}",
             match self {
                 Self::Ok => "OK",
-                Self::Fail => "FAIL",
                 Self::Timeout => "TIMEOUT",
                 Self::Crash => "CRASH",
                 Self::Error => "ERROR",
                 Self::Skip => "SKIP",
+                Self::Pass => "PASS",
+                Self::Fail => "FAIL",
             }
         )
     }
@@ -1157,11 +1159,12 @@ impl<'a> Properties<'a> for TestProps<TestOutcome> {
             helper,
             choice((
                 keyword("OK").to(TestOutcome::Ok),
-                keyword("FAIL").to(TestOutcome::Fail),
                 keyword("CRASH").to(TestOutcome::Crash),
                 keyword("TIMEOUT").to(TestOutcome::Timeout),
                 keyword("ERROR").to(TestOutcome::Error),
                 keyword("SKIP").to(TestOutcome::Skip),
+                keyword("PASS").to(TestOutcome::Pass),
+                keyword("FAIL").to(TestOutcome::Fail),
             )),
         )
         .boxed()
@@ -1363,24 +1366,6 @@ r#"
     );
 
     let parser = || single_leading_newline(Test::parser());
-
-    assert_debug_snapshot!(
-        parser().parse(
-r#"
-[asdf]
-  # Incorrect; `PASS` isn't a valid test outcome (but it _is_ a valid subtest outcome).
-  expected: PASS
-"#
-        ),
-        @r###"
-    ParseResult {
-        output: None,
-        errs: [
-            found end of input at 108..112 expected something else,
-        ],
-    }
-    "###
-    );
 
     assert_debug_snapshot!(
         parser().parse(
@@ -1635,7 +1620,7 @@ r#"
     assert_debug_snapshot!(
         parser().parse(r#"
 [canvas_complex_rgba8unorm_store.https.html]
-  expected: FAIL
+  expected: [PASS, FAIL, CRASH]
 
 "#),
     @r###"
@@ -1651,6 +1636,8 @@ r#"
                                 Collapsed(
                                     Collapsed(
                                         [
+                                            Crash,
+                                            Pass,
                                             Fail,
                                         ],
                                     ),

--- a/moz-webgpu-cts/src/metadata.rs
+++ b/moz-webgpu-cts/src/metadata.rs
@@ -1118,6 +1118,7 @@ where
 #[serde(rename_all = "UPPERCASE")]
 pub enum TestOutcome {
     Ok,
+    Fail,
     Timeout,
     Crash,
     Error,
@@ -1137,6 +1138,7 @@ impl Display for TestOutcome {
             "{}",
             match self {
                 Self::Ok => "OK",
+                Self::Fail => "FAIL",
                 Self::Timeout => "TIMEOUT",
                 Self::Crash => "CRASH",
                 Self::Error => "ERROR",
@@ -1155,6 +1157,7 @@ impl<'a> Properties<'a> for TestProps<TestOutcome> {
             helper,
             choice((
                 keyword("OK").to(TestOutcome::Ok),
+                keyword("FAIL").to(TestOutcome::Fail),
                 keyword("CRASH").to(TestOutcome::Crash),
                 keyword("TIMEOUT").to(TestOutcome::Timeout),
                 keyword("ERROR").to(TestOutcome::Error),
@@ -1622,6 +1625,40 @@ r#"
                             },
                         },
                     },
+                },
+            ),
+        ),
+        errs: [],
+    }
+    "###
+    );
+    assert_debug_snapshot!(
+        parser().parse(r#"
+[canvas_complex_rgba8unorm_store.https.html]
+  expected: FAIL
+
+"#),
+    @r###"
+    ParseResult {
+        output: Some(
+            (
+                "canvas_complex_rgba8unorm_store.https.html",
+                Test {
+                    properties: TestProps {
+                        is_disabled: false,
+                        expectations: Some(
+                            NormalizedExpectationPropertyValue(
+                                Collapsed(
+                                    Collapsed(
+                                        [
+                                            Fail,
+                                        ],
+                                    ),
+                                ),
+                            ),
+                        ),
+                    },
+                    subtests: {},
                 },
             ),
         ),

--- a/moz-webgpu-cts/src/shared.rs
+++ b/moz-webgpu-cts/src/shared.rs
@@ -351,8 +351,13 @@ impl<'a> TestPath<'a> {
             .map(|stripped| (TestScope::FirefoxPrivate, stripped))
             .or_else(|| {
                 test_url_path
-                    .strip_prefix('/')
+                    .strip_prefix("/_webgpu/")
                     .map(|stripped| (TestScope::Public, stripped))
+                    .or_else(|| {
+                        test_url_path
+                            .strip_prefix('/')
+                            .map(|stripped| (TestScope::Public, stripped))
+                    })
             })
         else {
             return Err(err());

--- a/moz-webgpu-cts/src/shared.rs
+++ b/moz-webgpu-cts/src/shared.rs
@@ -338,6 +338,8 @@ const SCOPE_DIR_FX_PRIVATE_STR: &str = "testing/web-platform/mozilla";
 const SCOPE_DIR_FX_PRIVATE_COMPONENTS: &[&str] = &["testing", "web-platform", "mozilla"];
 const SCOPE_DIR_FX_PUBLIC_STR: &str = "testing/web-platform";
 const SCOPE_DIR_FX_PUBLIC_COMPONENTS: &[&str] = &["testing", "web-platform"];
+const SCOPE_DIR_SERVO_PUBLIC_STR: &str = "tests/wpt/webgpu";
+const SCOPE_DIR_SERVO_PUBLIC_COMPONENTS: &[&str] = &["tests", "wpt", "webgpu"];
 
 impl<'a> TestPath<'a> {
     pub fn from_execution_report(
@@ -402,6 +404,8 @@ impl<'a> TestPath<'a> {
             if let Ok(path) = rel_meta_file_path.strip_prefix(SCOPE_DIR_FX_PRIVATE_STR) {
                 (TestScope::FirefoxPrivate, path)
             } else if let Ok(path) = rel_meta_file_path.strip_prefix(SCOPE_DIR_FX_PUBLIC_STR) {
+                (TestScope::Public, path)
+            } else if let Ok(path) = rel_meta_file_path.strip_prefix(SCOPE_DIR_SERVO_PUBLIC_STR) {
                 (TestScope::Public, path)
             } else {
                 return Err(err());
@@ -492,6 +496,7 @@ impl<'a> TestPath<'a> {
         } = self;
 
         let scope_dir = match scope {
+            // TODO: servo
             TestScope::Public => SCOPE_DIR_FX_PUBLIC_COMPONENTS,
             TestScope::FirefoxPrivate => SCOPE_DIR_FX_PRIVATE_COMPONENTS,
         }

--- a/moz-webgpu-cts/src/shared.rs
+++ b/moz-webgpu-cts/src/shared.rs
@@ -488,17 +488,23 @@ impl<'a> TestPath<'a> {
         })
     }
 
-    pub(crate) fn rel_metadata_path_fx(&self) -> impl Display + '_ {
+    pub(crate) fn rel_metadata_path_fx(&self, servo: bool) -> impl Display + '_ {
         let Self {
             path,
             variant: _,
             scope,
         } = self;
 
-        let scope_dir = match scope {
-            // TODO: servo
-            TestScope::Public => SCOPE_DIR_FX_PUBLIC_COMPONENTS,
-            TestScope::FirefoxPrivate => SCOPE_DIR_FX_PRIVATE_COMPONENTS,
+        let scope_dir = if !servo {
+            match scope {
+                TestScope::Public => SCOPE_DIR_FX_PUBLIC_COMPONENTS,
+                TestScope::FirefoxPrivate => SCOPE_DIR_FX_PRIVATE_COMPONENTS,
+            }
+        } else {
+            match scope {
+                TestScope::Public => SCOPE_DIR_SERVO_PUBLIC_COMPONENTS,
+                TestScope::FirefoxPrivate => todo!(),
+            }
         }
         .iter()
         .chain(&["meta"])


### PR DESCRIPTION
Currently `moz-webgpu-cts --servo process-reports --preset merge ../../Downloads/wpute/*` works on servo if all `disabled: comment` are replaced with `disabled: true`