### PR TITLE
servo: Handle multiple reports in same json file

### DIFF
--- a/moz-webgpu-cts/src/process_reports.rs
+++ b/moz-webgpu-cts/src/process_reports.rs
@@ -16,6 +16,7 @@ use indexmap::IndexMap;
 use lazy_format::lazy_format;
 use miette::{IntoDiagnostic, Report, WrapErr};
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
+use serde_json::Deserializer;
 use whippit::metadata::SectionHeader;
 
 use crate::{
@@ -286,17 +287,39 @@ pub(crate) fn process_reports(
                 .map_err(Report::msg)
                 .wrap_err("failed to open file")
                 .and_then(|reader| {
-                    serde_json::from_reader::<_, ExecutionReport>(reader)
-                        .map(Some)
-                        .or_else(|e| {
-                            if e.is_eof() && matches!((e.line(), e.column()), (1, 0)) {
-                                Ok(None)
-                            } else {
-                                Err(e)
-                            }
-                        })
-                        .into_diagnostic()
-                        .wrap_err("failed to parse JSON")
+                    if browser == Browser::Servo {
+                        // Servo can have two reports in same json file (two-record JSONL file)
+                        // First one is from the first run (all test are run/reported)
+                        // second one only runs unexpected results (from first run) for filtering
+                        //
+                        // TODO(sagudev): merge reports instead of using only first one
+                        let mut report_stream =
+                            Deserializer::from_reader(reader).into_iter::<ExecutionReport>();
+                        report_stream
+                            .next()
+                            .transpose()
+                            .or_else(|e| {
+                                if e.is_eof() && matches!((e.line(), e.column()), (1, 0)) {
+                                    Ok(None)
+                                } else {
+                                    Err(e)
+                                }
+                            })
+                            .into_diagnostic()
+                            .wrap_err("failed to parse JSON")
+                    } else {
+                        serde_json::from_reader::<_, ExecutionReport>(reader)
+                            .map(Some)
+                            .or_else(|e| {
+                                if e.is_eof() && matches!((e.line(), e.column()), (1, 0)) {
+                                    Ok(None)
+                                } else {
+                                    Err(e)
+                                }
+                            })
+                            .into_diagnostic()
+                            .wrap_err("failed to parse JSON")
+                    }
                 })
                 .wrap_err_with(|| {
                     format!(


### PR DESCRIPTION
Servo can have two reports in same json file (two-record JSONL file)
 
First one is from the first run (all test are run/reported)
second one only runs unexpected results (from first run) for filtering.

Ideally we info from second report too, but until then this will do.