### PR TITLE
Add `set` preset

### DIFF
--- a/moz-webgpu-cts/src/main.rs
+++ b/moz-webgpu-cts/src/main.rs
@@ -238,6 +238,8 @@ enum UpdateExpectedPreset {
     #[value(alias("same-build"))]
     Merge,
     ResetAll,
+    /// Sets only reported results
+    Set,
 }
 
 impl From<UpdateExpectedPreset> for process_reports::ReportProcessingPreset {
@@ -246,6 +248,7 @@ impl From<UpdateExpectedPreset> for process_reports::ReportProcessingPreset {
             UpdateExpectedPreset::ResetContradictory => Self::ResetContradictoryOutcomes,
             UpdateExpectedPreset::Merge => Self::MergeOutcomes,
             UpdateExpectedPreset::ResetAll => Self::ResetAllOutcomes,
+            UpdateExpectedPreset::Set => Self::SetNewOutcomes,
         }
     }
 }

--- a/moz-webgpu-cts/src/process_reports.rs
+++ b/moz-webgpu-cts/src/process_reports.rs
@@ -63,6 +63,7 @@ pub(crate) enum ReportProcessingPreset {
     ResetContradictoryOutcomes,
     MergeOutcomes,
     ResetAllOutcomes,
+    SetNewOutcomes,
 }
 
 #[derive(Debug, Default)]
@@ -134,6 +135,10 @@ fn reconcile<Out>(
                 }
                 ReportProcessingPreset::MergeOutcomes => |meta, rep| match rep {
                     Some(rep) => meta | rep,
+                    None => meta,
+                },
+                ReportProcessingPreset::SetNewOutcomes => |meta, rep| match rep {
+                    Some(rep) => rep,
                     None => meta,
                 },
             };
@@ -452,6 +457,7 @@ pub(crate) fn process_reports(
                         log::warn!("removing metadata after {msg}");
                         return None;
                     }
+                    ReportProcessingPreset::SetNewOutcomes => {}
                 }
             }
 
@@ -525,6 +531,7 @@ pub(crate) fn process_reports(
                                 log::warn!("removing metadata after {msg}");
                                 return None;
                             }
+                            ReportProcessingPreset::SetNewOutcomes => {}
                         }
                     }
 


### PR DESCRIPTION
Sets only reported results.

This is useful for partial runs (when only subset of tests are run). This is mostly useful for local development when focusing on fixing specific tests, I used this in servo a lot.

From #80 