### PR TITLE
feat(update_backlog)!: default `--only-across-all-platforms` to `false`

### DIFF
--- a/moz-webgpu-cts/src/main.rs
+++ b/moz-webgpu-cts/src/main.rs
@@ -293,7 +293,7 @@ enum OnZeroItem {
 enum UpdateBacklogSubcommand {
     /// Remove tests that expect only `PASS` outcomes on all platforms from `backlog`.
     PromotePermaPassing {
-        #[clap(long, default_value_t = true)]
+        #[clap(long)]
         only_across_all_platforms: bool,
     },
 }


### PR DESCRIPTION
This seems like it's ready for prime-time now. I've been using this pretty extensively in recent CTS updates for Firefox, and I'm confident it does the right thing. So, let's actually let users specify it!