### PR TITLE
Revert "Write tests in report order after processing reports (#163)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,7 +452,6 @@ checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown",
- "serde",
 ]
 
 [[package]]

--- a/moz-webgpu-cts/Cargo.toml
+++ b/moz-webgpu-cts/Cargo.toml
@@ -24,7 +24,7 @@ enum-map = { version = "2.7.3", features = ["serde"] }
 enumset = { version = "1.1.3", features = ["serde"] }
 env_logger = { workspace = true }
 format = { workspace = true }
-indexmap = { workspace = true, features = ["serde"] }
+indexmap = { workspace = true }
 itertools = "0.11.0"
 joinery = "3.1.0"
 lets_find_up = "0.0.3"

--- a/moz-webgpu-cts/src/wpt/metadata.rs
+++ b/moz-webgpu-cts/src/wpt/metadata.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeMap,
     fmt::{self, Display, Formatter},
     hash::Hash,
 };
@@ -7,7 +8,6 @@ use clap::ValueEnum;
 use enum_map::Enum;
 use enumset::EnumSetType;
 use format::lazy_format;
-use indexmap::IndexMap;
 use joinery::JoinableIterator;
 use maybe_collapsed::MaybeCollapsed;
 use serde::{Deserialize, Serialize};
@@ -45,7 +45,7 @@ pub(crate) mod properties;
 #[derive(Clone, Debug, Default, Serialize)]
 pub struct File {
     pub properties: FileProps,
-    pub tests: IndexMap<SectionHeader, Test>,
+    pub tests: BTreeMap<SectionHeader, Test>,
 }
 
 impl File {
@@ -650,7 +650,7 @@ impl ImplementationStatus {
 }
 
 #[derive(Debug, Default)]
-pub struct Tests(IndexMap<SectionHeader, Test>);
+pub struct Tests(BTreeMap<SectionHeader, Test>);
 
 impl<'a> metadata::Tests<'a> for Tests {
     type Test = Test;
@@ -673,7 +673,7 @@ impl<'a> metadata::Tests<'a> for Tests {
 #[derive(Clone, Debug, Default, Serialize)]
 pub struct Test {
     pub properties: TestProps<TestOutcome>,
-    pub subtests: IndexMap<SectionHeader, Subtest>,
+    pub subtests: BTreeMap<SectionHeader, Subtest>,
 }
 
 #[cfg(test)]
@@ -697,7 +697,7 @@ impl metadata::Test<'_> for Test {
 }
 
 #[derive(Default)]
-pub struct Subtests(IndexMap<SectionHeader, Subtest>);
+pub struct Subtests(BTreeMap<SectionHeader, Subtest>);
 
 impl<'a> metadata::Subtests<'a> for Subtests {
     type Subtest = Subtest;


### PR DESCRIPTION
Unfortunately, the main WPT test runner doesn't seem to report these in deterministic order! Looks like I might have jumped the gun in merging to `trunk` before validating the assumption that it would be deterministic in Firefox CI. 😅