### PR TITLE
fix: moz-webgpu-cts triage: Show only summary, not full analysis.

### DIFF
--- a/moz-webgpu-cts/src/main.rs
+++ b/moz-webgpu-cts/src/main.rs
@@ -939,7 +939,6 @@ fn run(cli: Cli) -> ExitCode {
                 let sections = sections.iter().filter_map(Option::as_ref).join_with("");
                 println!("{platform:?}:{sections}")
             });
-            println!("Full analysis: {analysis:#?}");
             ExitCode::SUCCESS
         }
         Subcommand::UpdateBacklog {

--- a/whippit/src/metadata/properties/unstructured.rs
+++ b/whippit/src/metadata/properties/unstructured.rs
@@ -138,7 +138,7 @@ impl<'a> Properties<'a> for UnstructuredProperties<'a> {
         if self.insert(key, value).is_some() {
             emitter.emit(Rich::custom(
                 key_span,
-                format!("duplicate {:?} property", key),
+                format!("duplicate {key:?} property"),
             ));
         }
     }


### PR DESCRIPTION
Change `moz-webgpu-cts` to print only the summary of the results, without dumping the full analysis. The latter is often thousands of lines long, and is not suitable for human consumption.