### PR TITLE
refactor: Remove needless conversions.

### DIFF
--- a/moz-webgpu-cts/src/main.rs
+++ b/moz-webgpu-cts/src/main.rs
@@ -529,11 +529,11 @@ fn run(cli: Cli) -> ExitCode {
                 }
             }
 
-            let test_count = u64::try_from(tests_by_name.len()).unwrap();
-            let subtest_count = tests_by_name
+            let test_count = tests_by_name.len();
+            let subtest_count: usize = tests_by_name
                 .values()
-                .map(|test| u64::try_from(test.inner.subtests.len()).unwrap())
-                .sum::<u64>();
+                .map(|test| test.inner.subtests.len())
+                .sum();
             let mut analysis = Analysis::default();
 
             for (test_name, test) in tests_by_name {

--- a/whippit/src/metadata/properties/unstructured.rs
+++ b/whippit/src/metadata/properties/unstructured.rs
@@ -138,7 +138,7 @@ impl<'a> Properties<'a> for UnstructuredProperties<'a> {
         if self.insert(key, value).is_some() {
             emitter.emit(Rich::custom(
                 key_span,
-                format!("duplicate {:?} property", key),
+                format!("duplicate {key:?} property"),
             ));
         }
     }


### PR DESCRIPTION
In `moz-webgpu-cts triage`, remove unnecessary conversions to `u64`.