### PR TITLE
Tweak ResetContradictory behavior

### DIFF
--- a/moz-webgpu-cts/src/wpt/metadata.rs
+++ b/moz-webgpu-cts/src/wpt/metadata.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::BTreeMap,
-    fmt::{self, Display, Formatter},
+    fmt::{self, Debug, Display, Formatter},
     hash::Hash,
 };
 
@@ -32,9 +32,9 @@ use whippit::{
     },
 };
 
-use crate::wpt::metadata::properties::{
+use crate::{process_reports::ReportProcessingPreset, wpt::metadata::properties::{
     DisabledString, ExpandedPropertyValue, Expected, NormalizedPropertyValue,
-};
+}};
 
 #[cfg(test)]
 use insta::assert_debug_snapshot;
@@ -917,6 +917,10 @@ pub enum Platform {
 pub enum BuildProfile {
     Debug,
     Optimized,
+}
+
+pub trait Reconcile {
+    fn reconcile(&self, observed: Self, preset: ReportProcessingPreset) -> Self;
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]


### PR DESCRIPTION
This tweaks the behavior of ResetContradictory for subtest outcomes to only consider expected pass vs. observed fail, or vice-versa, as contradictory. One or the other of pass/fail, vs. timeout/notrun, is not considered contradictory and in that case the updated expectation is the union of expected and observed outcomes.

I tried this with my try run from the recent wgpu update, and as best I can tell the change is working as intended but has no net effect on what updates get made to the expectations. It might do something if merging a run that only ran each test once, instead of 3x?

Given the lack of apparent benefit, I'm doubtful it's worth taking this change, but opening this for possible discussion.